### PR TITLE
Update maven plugin plugin to 3.4 as 3.2 failed while building on Java 8

### DIFF
--- a/wisdom-openjpa-enhancer-plugin/pom.xml
+++ b/wisdom-openjpa-enhancer-plugin/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <mavenVersion>3.1.0</mavenVersion>
-        <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+        <mavenPluginPluginVersion>3.4</mavenPluginPluginVersion>
         <plexusCompilerVersion>2.2</plexusCompilerVersion>
 
         <openjpa.version>2.4.0</openjpa.version>


### PR DESCRIPTION
Help-mojo was failing with : 
maven help-mojo java.lang.ArrayIndexOutOfBoundsException: 1894