### PR TITLE
Dependencies freshening !

### DIFF
--- a/openjpa-sample/README.md
+++ b/openjpa-sample/README.md
@@ -27,7 +27,7 @@ In the `application.conf` file, we add this configuration:
 # Data Source configuration
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 db.todo.driver="org.h2.Driver"
-db.todo.url ="jdbc:h2:database/todo.db"
+db.todo.url ="jdbc:h2:./database/todo.db"
 db.todo.logStatements=true
 ````
 
@@ -94,45 +94,32 @@ Here are the list of the Maven dependencies to use:
         <dependency>
             <groupId>org.apache.openjpa</groupId>
             <artifactId>openjpa</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-servlet_2.5_spec</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <!--Because ot the split packager from rt.jar, JTA is declared as a library -->
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-            <version>1.1.1</version>
-        </dependency>
+
         <dependency>
             <groupId>commons-dbcp</groupId>
             <artifactId>commons-dbcp</artifactId>
             <version>1.4</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.serp</artifactId>
-            <version>1.14.1_1</version>
+            <version>1.15.1_1</version>
         </dependency>
 
         <!-- JPA support and data source -->
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>wisdom-jpa-manager</artifactId>
-            <version>0.5-SNAPSHOT</version>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>h2</artifactId>
             <version>1.3.172_1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>wisdom-jdbc-datasources</artifactId>
-            <version>0.5-SNAPSHOT</version>
         </dependency>
 ````
 
@@ -145,7 +132,7 @@ classes:
 <plugin>
     <groupId>org.wisdom-framework</groupId>
     <artifactId>wisdom-openjpa-enhancer-plugin</artifactId>
-    <version>0.5-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
     <configuration>
         <includes>**/models/*.class</includes>
         <addDefaultConstructor>true</addDefaultConstructor>
@@ -160,13 +147,6 @@ classes:
             </goals>
         </execution>
     </executions>
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.openjpa</groupId>
-            <artifactId>openjpa</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-    </dependencies>
 </plugin>
 ````
 
@@ -179,7 +159,7 @@ declare JTA as a library:
 <plugin>
     <groupId>org.wisdom-framework</groupId>
     <artifactId>wisdom-maven-plugin</artifactId>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
     <extensions>true</extensions>
     <configuration>
         <skipGoogleClosure>true</skipGoogleClosure>

--- a/openjpa-sample/pom.xml
+++ b/openjpa-sample/pom.xml
@@ -22,9 +22,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.wisdom-framework</groupId>
+        <artifactId>wisdom-jdbc</artifactId>
+        <version>0.10.0-SNAPSHOT</version>
+    </parent>
+
     <groupId>org.wisdom-framework.jdbc</groupId>
     <artifactId>openjpa-sample</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
 
     <packaging>wisdom</packaging>
 
@@ -45,6 +51,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.enterprise</artifactId>
+            <version>5.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
             <version>3.1.1</version>
@@ -59,19 +71,9 @@
         <dependency>
             <groupId>org.apache.openjpa</groupId>
             <artifactId>openjpa</artifactId>
-            <version>2.3.0</version>
+            <version>${openjpa.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-servlet_2.5_spec</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <!--Because ot the split packager from rt.jar, JTA is declared as a library -->
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-            <version>1.1.1</version>
-        </dependency>
+
         <dependency>
             <groupId>commons-dbcp</groupId>
             <artifactId>commons-dbcp</artifactId>
@@ -80,36 +82,26 @@
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.serp</artifactId>
-            <version>1.14.1_1</version>
+            <version>1.15.1_1</version>
         </dependency>
 
         <!-- JPA support and data source -->
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>wisdom-jpa-manager</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.172_1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>wisdom-jdbc-datasources</artifactId>
-            <version>0.6-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>3.19.0-GA</version>
+            <version>1.4.191_1-SNAPSHOT</version>
         </dependency>
 
         <!-- Other applications -->
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>wisdom-monitor</artifactId>
-            <version>0.9.1</version>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -161,7 +153,7 @@
             <plugin>
                 <groupId>org.wisdom-framework</groupId>
                 <artifactId>wisdom-openjpa-enhancer-plugin</artifactId>
-                <version>0.6-SNAPSHOT</version>
+                <version>0.10.0-SNAPSHOT</version>
                 <configuration>
                     <includes>**/models/*.class</includes>
                     <addDefaultConstructor>true</addDefaultConstructor>
@@ -176,19 +168,12 @@
                         </goals>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.openjpa</groupId>
-                        <artifactId>openjpa</artifactId>
-                        <version>2.4.0</version>
-                    </dependency>
-                </dependencies>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.17</version>
+                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -227,15 +212,6 @@
                 <configuration>
                     <!-- should not be deployed -->
                     <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/openjpa-sample/src/main/configuration/application.conf
+++ b/openjpa-sample/src/main/configuration/application.conf
@@ -33,6 +33,6 @@ documentation.standalone=false
 # Data Source configuration
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 db.todo.driver="org.h2.Driver"
-db.todo.url="jdbc:h2:database/todo.db"
+db.todo.url="jdbc:h2:./database/todo.db"
 db.todo.logStatements=true
 

--- a/openjpa-sample/src/main/resources/assets/app/TodoListController.js
+++ b/openjpa-sample/src/main/resources/assets/app/TodoListController.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * Wisdom-Framework
+ * %%
+ * Copyright (C) 2013 - 2016 Wisdom Framework
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /* global $, Exception, console*/
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -10,11 +10,12 @@
   </parent>
 
   <artifactId>wisdom-jdbc</artifactId>
-  <version>0.6-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <properties>
     <!-- should match Wisdom parent -->
     <wisdom.version>0.10.0-SNAPSHOT</wisdom.version>
+    <openjpa.version>2.4.1</openjpa.version>
   </properties>
 
   <packaging>pom</packaging>
@@ -43,16 +44,34 @@
     </repository>
   </repositories>
 
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
   <profiles>
+
     <profile>
       <!-- require until the released Wisdom parent define the release profile -->
       <id>release</id>
       <build>
-        <plugins>
+
+          <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -67,10 +86,11 @@
               <useAgent>true</useAgent>
             </configuration>
           </plugin>
+
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>3.0.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -80,10 +100,11 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
+            <version>2.10.3</version>
             <executions>
               <execution>
                 <id>attach-javadoc</id>
@@ -93,7 +114,9 @@
               </execution>
             </executions>
           </plugin>
+
           <!-- We need to create a zip containing a buildable version of the project -->
+
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
             <dependencies>

--- a/wisdom-jdbc-datasources/pom.xml
+++ b/wisdom-jdbc-datasources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wisdom-jdbc-datasources</artifactId>
@@ -14,61 +14,69 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- The connection pool -->
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP-java6</artifactId>
-            <version>2.3.8</version>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>3.19.0-GA</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wisdom-api</artifactId>
+            <version>${wisdom.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- The connection pool -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>2.4.4</version>
+        </dependency>
+
         <!-- The JDBC drivers used for IT -->
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.184_2-SNAPSHOT</version>
+            <version>1.4.191_1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>derby</artifactId>
-            <version>10.11.1.1_3-SNAPSHOT</version>
+            <version>10.12.1.1_1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.3.2_3-SNAPSHOT</version>
+            <version>2.3.3_1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.8.7_2-SNAPSHOT</version>
+            <version>3.8.11.2_1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34_2-SNAPSHOT</version>
+            <version>5.1.38_1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.1-903.jdbc4_1-SNAPSHOT</version>
+            <version>9.4.1208_1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
@@ -76,13 +84,7 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.enterprise</artifactId>
             <version>5.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wisdom-api</artifactId>
-            <version>${wisdom.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -104,10 +106,6 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -115,7 +113,6 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -132,23 +129,11 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-        </dependency>
-
     </dependencies>
 
 
     <build>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.wisdom-framework</groupId>
                 <artifactId>wisdom-maven-plugin</artifactId>
@@ -160,10 +145,11 @@
                     <disableDistributionPackaging>true</disableDistributionPackaging>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
+                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/wisdom-jdbc-datasources/src/main/java/org/wisdom/database/jdbc/impl/HikariCPDataSources.java
+++ b/wisdom-jdbc-datasources/src/main/java/org/wisdom/database/jdbc/impl/HikariCPDataSources.java
@@ -389,7 +389,9 @@ public class HikariCPDataSources implements DataSources {
             HikariDataSource ds = entry.getValue();
             if (ds != null && driverClassName.equals(getRequiredDriver(entry.getKey()))) {
                 // A used driver just left....
+                //TODO Unregister only the leaving Datasource service ?
                 unregister();
+                //TODO remove the entry completely ?
                 sources.put(entry.getKey(), null);
                 LOGGER.info("Driver {} left the DataSourceFactory", driverClassName);
             }
@@ -399,9 +401,10 @@ public class HikariCPDataSources implements DataSources {
     private void shutdownPool(HikariDataSource source) {
         LOGGER.info("Shutting down connection pool.");
         if (source != null) {
-            source.shutdown();
+            source.close();
         } else {
-            throw new IllegalArgumentException("Cannot close a data source not managed by the manager :" + source);
+            LOGGER.error("Cannot close a data source not managed by the manager (not anymore at least) : {}", source);
+            //throw new IllegalArgumentException("Cannot close a data source not managed by the manager :" + source);
         }
     }
 

--- a/wisdom-jdbc-drivers/abstract-jdbc-driver/pom.xml
+++ b/wisdom-jdbc-drivers/abstract-jdbc-driver/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc-drivers</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>abstract-jdbc-driver</artifactId>
@@ -15,22 +15,32 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.enterprise</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.ipojo.annotations</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.enterprise</artifactId>
+        </dependency>
+
+        <!-- Tests -->
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+
         </dependency>
+
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>

--- a/wisdom-jdbc-drivers/derby/pom.xml
+++ b/wisdom-jdbc-drivers/derby/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc-drivers</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>derby</artifactId>
-    <version>10.11.1.1_3-SNAPSHOT</version>
+    <version>10.12.1.1_1-SNAPSHOT</version>
 
     <packaging>bundle</packaging>
     <properties>
@@ -18,32 +18,37 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>10.11.1.1</version>
-            <scope>provided</scope>
+            <groupId>org.wisdom-framework</groupId>
+            <artifactId>abstract-jdbc-driver</artifactId>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.enterprise</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.12.1.1</version>
+            <scope>provided</scope>
         </dependency>
+
+        <!-- Tests -->
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>abstract-jdbc-driver</artifactId>
-            <version>0.6-SNAPSHOT</version>
-        </dependency>
+
     </dependencies>
 
     <build>
@@ -61,6 +66,7 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-ipojo-plugin</artifactId>

--- a/wisdom-jdbc-drivers/h2/pom.xml
+++ b/wisdom-jdbc-drivers/h2/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc-drivers</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>h2</artifactId>
-    <version>1.4.184_2-SNAPSHOT</version>
+    <version>1.4.191_1-SNAPSHOT</version>
 
     <packaging>bundle</packaging>
     <properties>
@@ -18,32 +18,36 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>${project.artifactId}</artifactId>
-            <version>1.4.184</version>
-            <!-- Classes are embedded in the bundle -->
-            <scope>provided</scope>
+            <groupId>org.wisdom-framework</groupId>
+            <artifactId>abstract-jdbc-driver</artifactId>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.enterprise</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
+            <groupId>com.h2database</groupId>
+            <artifactId>${project.artifactId}</artifactId>
+            <version>1.4.191</version>
+            <!-- Classes are embedded in the bundle -->
+            <scope>provided</scope>
         </dependency>
+
+        <!-- Tests -->
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>abstract-jdbc-driver</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -62,6 +66,7 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-ipojo-plugin</artifactId>

--- a/wisdom-jdbc-drivers/hsql/pom.xml
+++ b/wisdom-jdbc-drivers/hsql/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc-drivers</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hsqldb</artifactId>
-    <version>2.3.2_3-SNAPSHOT</version>
+    <version>2.3.3_1-SNAPSHOT</version>
 
     <packaging>bundle</packaging>
     <properties>
@@ -18,30 +18,34 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <version>2.3.2</version>
+            <groupId>org.wisdom-framework</groupId>
+            <artifactId>abstract-jdbc-driver</artifactId>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.enterprise</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.3.3</version>
         </dependency>
+
+        <!-- Tests -->
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>abstract-jdbc-driver</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -60,6 +64,7 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-ipojo-plugin</artifactId>

--- a/wisdom-jdbc-drivers/mysql/pom.xml
+++ b/wisdom-jdbc-drivers/mysql/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc-drivers</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>mysql-connector-java</artifactId>
-    <version>5.1.34_2-SNAPSHOT</version>
+    <version>5.1.38_1-SNAPSHOT</version>
 
     <packaging>bundle</packaging>
     <properties>
@@ -18,31 +18,35 @@
 
     <dependencies>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.34</version>
-            <scope>provided</scope>
+            <groupId>org.wisdom-framework</groupId>
+            <artifactId>abstract-jdbc-driver</artifactId>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.enterprise</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.38</version>
+            <scope>provided</scope>
         </dependency>
+
+        <!-- Tests -->
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>abstract-jdbc-driver</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -61,6 +65,7 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-ipojo-plugin</artifactId>

--- a/wisdom-jdbc-drivers/pom.xml
+++ b/wisdom-jdbc-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wisdom-jdbc-drivers</artifactId>
@@ -23,7 +23,5 @@
         <module>postgresql</module>
         <module>mysql</module>
     </modules>
-
-
 
 </project>

--- a/wisdom-jdbc-drivers/postgresql/pom.xml
+++ b/wisdom-jdbc-drivers/postgresql/pom.xml
@@ -5,12 +5,11 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc-drivers</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>postgresql</artifactId>
-    <version>9.4-1201-jdbc41_1-SNAPSHOT</version>
-
+    <version>9.4.1208_1-SNAPSHOT</version>
 
     <packaging>bundle</packaging>
     <properties>
@@ -19,31 +18,34 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>9.4-1201-jdbc41</version>
+            <groupId>org.wisdom-framework</groupId>
+            <artifactId>abstract-jdbc-driver</artifactId>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.enterprise</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>9.4.1208</version>
         </dependency>
+
+        <!-- Tests -->
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>abstract-jdbc-driver</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -62,6 +64,7 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-ipojo-plugin</artifactId>

--- a/wisdom-jdbc-drivers/sqlite/pom.xml
+++ b/wisdom-jdbc-drivers/sqlite/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc-drivers</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sqlite-jdbc</artifactId>
-    <version>3.8.7_2-SNAPSHOT</version>
+    <version>3.8.11.2_1-SNAPSHOT</version>
 
     <packaging>bundle</packaging>
     <properties>
@@ -18,31 +18,35 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <version>3.8.7</version>
-            <scope>provided</scope>
+            <groupId>org.wisdom-framework</groupId>
+            <artifactId>abstract-jdbc-driver</artifactId>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.enterprise</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.ipojo.annotations</artifactId>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.8.11.2</version>
+            <scope>provided</scope>
         </dependency>
+
+        <!-- Tests -->
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>abstract-jdbc-driver</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -61,6 +65,7 @@
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-ipojo-plugin</artifactId>

--- a/wisdom-jpa-manager/pom.xml
+++ b/wisdom-jpa-manager/pom.xml
@@ -1,69 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wisdom-jpa-manager</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
 
     <packaging>wisdom</packaging>
 
     <dependencies>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+
+        <!-- Wisdom related -->
+
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.ipojo.annotations</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
+
+        <!-- Embedded -->
+
         <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>wisdom-test</artifactId>
-            <version>${wisdom.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jcl</artifactId>
-            <version>1.7.6</version>
+            <groupId>org.objectweb.howl</groupId>
+            <artifactId>howl</artifactId>
+            <version>1.0.1-1</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
-            <!-- Used in test -->
-            <groupId>${project.groupId}</groupId>
-            <artifactId>application-configuration</artifactId>
-            <version>${wisdom.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <groupId>org.apache.geronimo.components</groupId>
+            <artifactId>geronimo-transaction</artifactId>
+            <version>3.1.3</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Provided by the framework (because of the split package between the JRE and the spec -->
+
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jta_1.1_spec</artifactId>
@@ -71,135 +53,147 @@
         </dependency>
 
         <!-- Embedded but also provided to let openjpa being resolved -->
+
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jpa_2.0_spec</artifactId>
             <version>1.1</version>
         </dependency>
 
-        <!-- Embedded -->
-        <dependency>
-            <groupId>org.objectweb.howl</groupId>
-            <artifactId>howl</artifactId>
-            <version>1.0.1-1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.components</groupId>
-            <artifactId>geronimo-transaction</artifactId>
-            <version>3.1.1</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Dependency -->
+
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>wisdom-jdbc-datasources</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <version>0.10.0-SNAPSHOT</version>
         </dependency>
+
+        <!-- For Testing purpose -->
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
+            <scope>test
+            </scope>
         </dependency>
 
-
-        <!-- For Testing purpose -->
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP-java6</artifactId>
-            <version>2.3.8</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <version>3.19.0-GA</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.openjpa</groupId>
-            <artifactId>openjpa</artifactId>
-            <version>2.4.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xbean</groupId>
-            <artifactId>xbean-asm5-shaded</artifactId>
-            <version>3.17</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!-- Required by openjpa -->
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-servlet_2.5_spec</artifactId>
-            <version>1.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
-            <version>1.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-pool</groupId>
-            <artifactId>commons-pool</artifactId>
-            <version>1.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xbean</groupId>
-            <artifactId>xbean-asm4-shaded</artifactId>
-            <version>3.16</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.179</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wisdom-framework</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.3.172_1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.serp</artifactId>
-            <version>1.14.1_1</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.ow2.chameleon</groupId>
-            <artifactId>chameleon-core</artifactId>
+            <groupId>org.wisdom-framework</groupId>
+            <artifactId>wisdom-test</artifactId>
+            <version>${wisdom.version}</version>
+            <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jcl</artifactId>
+            <version>1.7.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <!-- Used in test -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>application-configuration</artifactId>
+            <version>${wisdom.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.xbean</groupId>
+            <artifactId>xbean-asm5-shaded</artifactId>
+            <version>3.18</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>2.4.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-pool</groupId>
+            <artifactId>commons-pool</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- H2 database in tests -->
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.191</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wisdom-framework</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.191_1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- OpenJPA in tests -->
+
+        <dependency>
+            <groupId>org.apache.openjpa</groupId>
+            <artifactId>openjpa</artifactId>
+            <version>${openjpa.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.serp</artifactId>
+            <version>1.15.1_1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-dbcp</groupId>
+            <artifactId>commons-dbcp</artifactId>
+            <version>1.4</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>2.2</version>
                 <executions>
                     <execution>
                         <id>xjc</id>
@@ -213,6 +207,7 @@
                     <packageName>org.wisdom.framework.jpa.model</packageName>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.wisdom-framework</groupId>
                 <artifactId>wisdom-maven-plugin</artifactId>
@@ -233,10 +228,11 @@
                     </libraries>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.openjpa</groupId>
                 <artifactId>openjpa-maven-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.1</version>
                 <configuration>
                     <includes>**/entities/**/*.class</includes>
                     <addDefaultConstructor>true</addDefaultConstructor>
@@ -252,10 +248,11 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
+                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/wisdom-openjpa-enhancer-plugin/pom.xml
+++ b/wisdom-openjpa-enhancer-plugin/pom.xml
@@ -5,29 +5,26 @@
     <parent>
         <groupId>org.wisdom-framework</groupId>
         <artifactId>wisdom-jdbc</artifactId>
-        <version>0.6-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wisdom-openjpa-enhancer-plugin</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 
     <properties>
         <mavenVersion>3.1.0</mavenVersion>
-        <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+        <mavenPluginPluginVersion>3.4</mavenPluginPluginVersion>
         <plexusCompilerVersion>2.2</plexusCompilerVersion>
-
-        <openjpa.version>2.4.0</openjpa.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.wisdom-framework</groupId>
             <artifactId>wisdom-maven-plugin</artifactId>
-            <version>0.10.0-SNAPSHOT</version>
+            <version>${wisdom.version}</version>
         </dependency>
-
 
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -46,6 +43,7 @@
             <artifactId>maven-artifact</artifactId>
             <version>${mavenVersion}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>


### PR DESCRIPTION
Need tests and reviews !

Major points are : 
- Java 8 compilation
- jdbc-datasources now use HikariCP 2.4.4 (as Wisdom is now Java 8, no need to keep HikariCP-java6)
- openjpa 2.4.1 everywhere
- Version update to 0.10.0-SNAPSHOT (syncing with wisdom + reflect HikariCP & OpenJPA update)
- Database drivers update (all to latest)
- Dependencies cleanup