### PR TITLE
Reuse PersistenceUnits across several persistence.xml

### DIFF
--- a/wisdom-jpa-manager/src/main/java/org/wisdom/framework/jpa/JPAManager.java
+++ b/wisdom-jpa-manager/src/main/java/org/wisdom/framework/jpa/JPAManager.java
@@ -30,12 +30,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wisdom.framework.jpa.model.Persistence;
 
-import javax.persistence.spi.PersistenceProvider;
 import javax.xml.bind.JAXB;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * The entry point of the JPA bridge.
@@ -55,6 +55,8 @@ public class JPAManager {
      * The logger.
      */
     private final static Logger LOGGER = LoggerFactory.getLogger(JPAManager.class);
+
+    private Map<String, Persistence.PersistenceUnit> pus = new HashMap<>();
 
     /**
      * The bundle context, used to register the tracker.
@@ -115,6 +117,7 @@ public class JPAManager {
              */
             @Override
             public void removedBundle(Bundle bundle, BundleEvent event, PersistentBundle pu) {
+
                 pu.destroy();
             }
         };
@@ -185,12 +188,20 @@ public class JPAManager {
                 Persistence persistence = JAXB.unmarshal(url, Persistence.class);
                 LOGGER.info("Parsed persistence: {}, unit {}", persistence, persistence.getPersistenceUnit());
                 for (Persistence.PersistenceUnit pu : persistence.getPersistenceUnit()) {
-                    if (pu.getProperties() == null) {
-                        pu.setProperties(new Persistence.PersistenceUnit.Properties());
+                    final String jta = pu.getJtaDataSource();
+                    if(!pus.containsKey(jta)) {
+                        if (pu.getProperties() == null) {
+                            pu.setProperties(new Persistence.PersistenceUnit.Properties());
+                        }
+                        pu.getProperties().getProperty().add(p);
+                        set.add(pu);
+                        pus.put(jta, pu);
+                        LOGGER.info("Adding persistence unit {}", pu);
+                    } else {
+                        Persistence.PersistenceUnit previousPu = pus.get(jta);
+                        previousPu.getClazz().addAll(pu.getClazz());
+                        LOGGER.info("Recycling persistence unit {}", previousPu);
                     }
-                    pu.getProperties().getProperty().add(p);
-                    set.add(pu);
-                    LOGGER.info("Adding persistence unit {}", pu);
                 }
             }
         }


### PR DESCRIPTION
When entities are defined in several bundles' persistence.xml but on the same jta-datasource there are the same amount of EntityManager created, each working with one subset of this datasource. After that Native and JPQL queries fails. 
Entities on the same jta-datasource should be handled in the same EntityManager 

This works only for bundles loaded before Datasources validate as we inject classes from new persistence.xml on a given jta-datasource in the initial persistence.xml. Once the jta-datasource is available the PersistenceUnitComponent validate and all classes added afterwards won't be available in the EntityManager.
